### PR TITLE
add options for plotting fewer modules

### DIFF
--- a/python/main.py
+++ b/python/main.py
@@ -223,7 +223,7 @@ def create_mesh(header, modules_only=False, show_det_eff=False, random_color=Fal
                 shapes.append(module_mesh)
 
             module_count += 1
-            if num_modules >= 0 and module_count > (num_modules * (skip_modules + 1)):
+            if num_modules > 0 and module_count + skip_modules + 1 > (num_modules * (skip_modules + 1)):
                 break
 
     if fov is not None:

--- a/python/main.py
+++ b/python/main.py
@@ -319,10 +319,10 @@ if __name__ == "__main__":
     with petsird.BinaryPETSIRDReader(file) as reader:
         header = reader.read_header()
 
-        # Forced to do this
-        for time_block in reader.read_time_blocks():
-            pass
-
         mesh = create_mesh(header, args.modules_only, args.show_det_eff, args.random_color, args.fov,
                            args.num_modules, args.skip_modules)
         mesh.export(output_fname)
+
+        # Forced to do this
+        for time_block in reader.read_time_blocks():
+            pass

--- a/python/main.py
+++ b/python/main.py
@@ -223,7 +223,7 @@ def create_mesh(header, modules_only=False, show_det_eff=False, random_color=Fal
                 shapes.append(module_mesh)
 
             module_count += 1
-            if num_modules >= 0 and module_count >= (num_modules * (skip_modules + 1)):
+            if num_modules >= 0 and module_count > (num_modules * (skip_modules + 1)):
                 break
 
     if fov is not None:


### PR DESCRIPTION
For real scanners, there's quite a lot of stuff to plot. With these options, you can decide to plot only a few modules. This helped me to debug my geometry. For instance,
![image](https://github.com/user-attachments/assets/12b344e1-07cf-4921-b40f-a261f0fd02e1)

I've also moved the (temporary work-around of) reading of all time-blocks to the end, such that I can press Ctrl-C and avoid waiting for a long time.