### PR TITLE
Add possibility to set a `--skip-modules` option without setting a `--num-modules`

### DIFF
--- a/python/main.py
+++ b/python/main.py
@@ -349,21 +349,17 @@ if __name__ == "__main__":
         file = open(args.input, "rb")
     output_fname = args.output
 
-    with petsird.BinaryPETSIRDReader(file) as reader:
-        header = reader.read_header()
+    reader = petsird.BinaryPETSIRDReader(file)
+    header = reader.read_header()
+    if args.num_modules > 0:
+        module_indices = range(0, args.num_modules * (args.skip_modules + 1), args.skip_modules + 1)
+    elif args.skip_modules > 0:
+        module_indices = UnknownStopRange(0, step=args.skip_modules + 1)
+    else:
+        module_indices = None
 
-        if args.num_modules > 0:
-            module_indices = range(0, args.num_modules * (args.skip_modules + 1), args.skip_modules + 1)
-        elif args.skip_modules > 0:
-            module_indices = UnknownStopRange(0, step=args.skip_modules + 1)
-        else:
-            module_indices = None
+    mesh = create_mesh(header, args.modules_only, args.show_det_eff, args.random_color, args.fov,
+                        module_indices
+    )
+    mesh.export(output_fname)
 
-        mesh = create_mesh(header, args.modules_only, args.show_det_eff, args.random_color, args.fov,
-                          module_indices
-        )
-        mesh.export(output_fname)
-
-        # Forced to do this
-        for time_block in reader.read_time_blocks():
-            pass


### PR DESCRIPTION
## Changes in this pull request

This fixes a problem that occurs when the user specifies a `--skip-module` option, but no `--num-modules` option.
This has been broken since we started using `module_indices=` in commit `c0c9518`.
In order to fix this, I had to create a custom class that defines a range that doesn't have a "stop" number, but that can still check if an element is in the range.

This is useful if a user wants to display all the scanner, but also wants to skip a set amount of modules.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added docstrings/doxygen in line with the guidance in the developer guide
- [x] The code builds and runs on my machine

## Contribution Notes

Please read and adhere to the [contribution guidelines](https://github.com/ETSInitiative/PRDdefinition/blob/master/CONTRIBUTING.md).

Please tick the following: 

 - [x] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in the ETSI software (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License.
